### PR TITLE
SE-1014 Updates jenkins and job DSL

### DIFF
--- a/playbooks/roles/jenkins_analytics/defaults/main.yml
+++ b/playbooks/roles/jenkins_analytics/defaults/main.yml
@@ -223,3 +223,75 @@ jenkins_seed_job:
     additional_classpath: "{{ ANALYTICS_SCHEDULE_JOBS_DSL_CLASSPATH }}"
     target_jobs: "{{ ANALYTICS_SCHEDULE_JOBS_DSL_TARGET_JOBS }}"
 
+jenkins_analytics_plugins:
+    - { name: "ansicolor", version: "0.4.1" }
+    - { name: "ant", version: "1.2" }
+    - { name: "build-flow-plugin", version: "0.17" }
+    - { name: "build-flow-test-aggregator", version: "1.0" }
+    - { name: "build-flow-toolbox-plugin", version: "0.1" }
+    - { name: "build-name-setter", version: "1.3" }
+    - { name: "build-pipeline-plugin", version: "1.4" }
+    - { name: "build-timeout", version: "1.14.1" }
+    - { name: "build-user-vars-plugin", version: "1.5" }
+    - { name: "buildgraph-view", version: "1.1.1" }
+    - { name: "cloudbees-folder", version: "5.2.1" }
+    - { name: "cobertura", version: "1.9.6" }
+    - { name: "copyartifact", version: "1.32.1" }
+    - { name: "copy-to-slave", version: "1.4.3" }
+    - { name: "credentials", version: "2.1.4" }
+    - { name: "credentials-binding", version: "1.10" }
+    - { name: "dashboard-view", version: "2.9.1" }
+    - { name: "ec2", version: "1.28" }
+    - { name: "envinject", version: "1.92.1" }
+    - { name: "external-monitor-job", version: "1.4" }
+    - { name: "ghprb", version: "1.22.4" }
+    - { name: "git", version: "2.4.0"}
+    - { name: "git-client", version: "1.19.0"}
+    - { name: "github", version: "1.14.0" }
+    - { name: "github-api", version: "1.69" }
+    - { name: "github-oauth", version: "0.22.3" }
+    - { name: "github-sqs-plugin", version: "1.5" }
+    - { name: "gradle", version: "1.24" }
+    - { name: "grails", version: "1.7" }
+    - { name: "groovy-postbuild", version: "2.2" }
+    - { name: "htmlpublisher", version: "1.3" }
+    - { name: "javadoc", version: "1.3" }
+    - { name: "jobConfigHistory", version: "2.10" }
+    - { name: "job-dsl", version: "1.43" }
+    - { name: "junit", version: "1.3" }
+    - { name: "ldap", version: "1.11" }
+    - { name: "mailer", version: "1.16" }
+    - { name: "mapdb-api", version: "1.0.6.0" }
+    - { name: "mask-passwords", version: "2.8" }
+    - { name: "matrix-auth", version: "1.2" }
+    - { name: "matrix-project", version: "1.4" }
+    - { name: "monitoring", version: "1.56.0" }
+    - { name: "multiple-scms", version: "0.5" }
+    - { name: "nested-view", version: "1.10" }
+    - { name: "next-build-number", version: "1.0" }
+    - { name: "node-iterator-api", version: "1.5" }
+    - { name: "notification", version: "1.5" }
+    - { name: "pam-auth", version: "1.2" }
+    - { name: "parameterized-trigger", version: "2.25" }
+    - { name: "postbuild-task", version: "1.8" }
+    - { name: "plain-credentials", version: "1.1" }
+    - { name: "PrioritySorter", version: "2.9" }
+    - { name: "rebuild", version: "1.25" }
+    - { name: "sauce-ondemand", version: "1.61" }
+    - { name: "scm-api", version: "0.2" }
+    - { name: "script-security", version: "1.12" }
+    - { name: "s3", version: "0.6" }
+    - { name: "ssh-agent", version: "1.5" }
+    - { name: "ssh-credentials", version: "1.11" }
+    - { name: "ssh-slaves", version: "1.9" }
+    - { name: "shiningpanda", version: "0.23" }
+    - { name: "throttle-concurrents", version: "1.9.0" }
+    - { name: "tmpcleaner", version: "1.1" }
+    - { name: "token-macro", version: "1.10" }
+    - { name: "timestamper", version: "1.5.15" }
+    - { name: "thinBackup", version: "1.7.4" }
+    - { name: "translation", version: "1.12" }
+    - { name: "violations", version: "0.7.11" }
+    - { name: "windows-slaves", version: "1.0" }
+    - { name: "workflow-step-api", version: "1.14.2" }
+    - { name: "xunit", version: "1.93"}

--- a/playbooks/roles/jenkins_analytics/meta/main.yml
+++ b/playbooks/roles/jenkins_analytics/meta/main.yml
@@ -1,2 +1,3 @@
 dependencies:
-  - jenkins_master
+  - role: jenkins_master
+    jenkins_plugins: "{{ jenkins_analytics_plugins }}"

--- a/playbooks/roles/jenkins_analytics/templates/seedJob.groovy
+++ b/playbooks/roles/jenkins_analytics/templates/seedJob.groovy
@@ -13,15 +13,17 @@ job('{{ jenkins_seed_job.name }}') {
       remote {
         url('{{ scm.url }}')
         branch("{{ scm.branch | default('master') }}")
-        {% if scm.dest %}
-          relativeTargetDir('{{ scm.dest }}')
-        {% endif %}
         {% if scm.credential_id %}
           credentials('{{ scm.credential_id }}')
         {% endif %}
       }
-      clean(true)
-      pruneBranches(true)
+      extensions {
+        {% if scm.dest %}
+          relativeTargetDirectory('{{ scm.dest }}')
+        {% endif %}
+        cleanAfterCheckout()
+        pruneBranches()
+      }
     }
     {% endif %}
   {% endfor %}

--- a/playbooks/roles/jenkins_master/defaults/main.yml
+++ b/playbooks/roles/jenkins_master/defaults/main.yml
@@ -6,8 +6,8 @@ jenkins_port: 8080
 jenkins_nginx_port: 80
 jenkins_protocol_https: true
 
-jenkins_version: "1.638"
-jenkins_deb_url: "http://pkg.jenkins-ci.org/debian/binary/jenkins_{{ jenkins_version }}_all.deb"
+jenkins_version: '1.651.3'
+jenkins_deb_url: "https://pkg.jenkins.io/debian-stable/binary/jenkins_{{ jenkins_version }}_all.deb"
 jenkins_deb: "jenkins_{{ jenkins_version }}_all.deb"
 # Jenkins jvm args are set when starting the Jenkins service, e.g., "-Xmx1024m"
 jenkins_jvm_args: ""
@@ -90,11 +90,7 @@ jenkins_bundled_plugins:
     - "ssh-credentials"
     - "ssh-slaves"
 
-jenkins_custom_plugins:
-    - { repo_name: "github-sqs-plugin",
-        repo_url: "https://github.com/jzoldak/github-sqs-plugin.git",
-        package: "github-sqs-plugin.hpi",
-        version: "a6069caf072f13178c0c83b3b95f4d6ae12caad0" }
+jenkins_custom_plugins: []
 
 jenkins_debian_pkgs:
     - nginx

--- a/playbooks/roles/jenkins_master/meta/main.yml
+++ b/playbooks/roles/jenkins_master/meta/main.yml
@@ -1,9 +1,6 @@
 ---
 dependencies:
   - common
+  - nginx
   - role: oraclejdk
     tags: java
-    oraclejdk_version: "7u51"
-    oraclejdk_base: "jdk1.7.0_51"
-    oraclejdk_build: "b13"
-    oraclejdk_link: "/usr/lib/jvm/java-7-oracle"

--- a/playbooks/roles/jenkins_master/tasks/main.yml
+++ b/playbooks/roles/jenkins_master/tasks/main.yml
@@ -249,23 +249,6 @@
     - install:base
     - install:plugins
 
-- name: Setup nginx vhost
-  template:
-    src: "etc/nginx/sites-available/jenkins.j2"
-    dest: "{{ nginx_sites_available_dir }}/jenkins"
-  tags:
-    - install
-    - install:vhosts
-
-- name: Enable jenkins vhost
-  file:
-    src: "{{ nginx_sites_available_dir }}/jenkins"
-    dest: "{{ nginx_sites_enabled_dir }}/jenkins"
-    state: link
-  tags:
-    - install
-    - install:vhosts
-
 - include: datadog.yml
   when: COMMON_ENABLE_DATADOG
   tags:


### PR DESCRIPTION
Updates jenkins roles to match master, and applies fixes to the analytics seed job DSL to support the installed versions of the job-dsl libraries.

These steps were required to deploy the admin Jenkins server for Campus stage.

**Testing instructions**:

1. Update your `.ssh/config` and proxy according to the updated [Olive Internal wiki](https://github.com/edx-olive/olive-internal/wiki).
1. Visit https://admin-stage.stage.edx-flatu.org:8080/ and accept the OAuth application privileges requested.
1. Members of the [`edx-olive:jenkins-admins` team](https://github.com/orgs/edx-olive/teams/jenkins-admins) can view, update, and run jenkins analytics jobs.
   Ensure that the AnalyticsSeedJob and its 5 analytics jobs are present and have been run successfully.  (Yellow "unstable" seems to be the best I can get out of the AnalyticsSeedJob, and it's ok to ignore the pipeline-acceptance-test.)

**Author notes and concerns**:

1. Decided to use the upstream master versions of these jenkins roles because of issues encountered when running the olive version, and in an attempt to see if updating Jenkins avoids the periodic issues we have in prod admin where Jenkins runs out of file handles.
1. Upstreamed the seedJob.dsl with https://github.com/edx/configuration/pull/5115.

**Reviewers**
- [ ] @pkulkark 

CC @edx-olive/edx-devops 