### PR TITLE
[SE-1194] Delete root volumes on termination

### DIFF
--- a/util/vpc-tools/abbey.py
+++ b/util/vpc-tools/abbey.py
@@ -559,7 +559,8 @@ rm -rf $base_dir
 
     mapping = BlockDeviceMapping()
     root_vol = BlockDeviceType(size=args.root_vol_size,
-                               volume_type='gp2')
+                               volume_type='gp2',
+                               delete_on_termination=True)
     mapping['/dev/sda1'] = root_vol
 
     ec2_args = {


### PR DESCRIPTION
This instructs abbey.py to use BlockDeviceMapping with a default BlockDeviceType delete_on_termination setting of True.