### PR TITLE
SE-1278 prevent failure state on successful seedjob build

### DIFF
--- a/playbooks/roles/jenkins_analytics/tasks/main.yml
+++ b/playbooks/roles/jenkins_analytics/tasks/main.yml
@@ -217,5 +217,6 @@
   include: execute_jenkins_cli.yaml
   vars:
     jenkins_command_string: "build {{ jenkins_seed_job.name }} -s"
+    jenkins_ignore_cli_errors: yes
   tags:
     - jenkins-seed-job


### PR DESCRIPTION
Note that this may not be the best solution, as it will not pick up an actual failure state.