### PR TITLE
SE-1787 backport upstreamed mongo backup changes

### DIFF
--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -107,4 +107,3 @@ mongo_backup_cron:
   day: '*'
   month: '*'
   weekday: '*'
-is_backup_node: false

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -107,3 +107,4 @@ mongo_backup_cron:
   day: '*'
   month: '*'
   weekday: '*'
+is_backup_node: false

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -107,3 +107,7 @@ mongo_backup_cron:
   day: '*'
   month: '*'
   weekday: '*'
+
+# Internal variable set to true dynamically if backups enabled and playbook running on MONGO_BACKUP_NODE. Do not
+# manually override.
+is_backup_node: false

--- a/playbooks/roles/mongo_3_2/defaults/main.yml
+++ b/playbooks/roles/mongo_3_2/defaults/main.yml
@@ -87,15 +87,19 @@ mongo_enable_journal: true
 
 MONGO_LOG_SERVERSTATUS: true
 
-# backups vars. These must all be set according to your mongo instance setup
+# Vars for configuring a mongo backup node. If enabled, this node will be provisioned with a script that uses mongodump
+# to backup the database to an ebs volume at a period set by mongo_backup_cron.
+# Set MONGO_BACKUP_ENABLED to true to enable. If enabled, all the other MONGO_BACKUP_ vars must be set according to your
+# setup.
+MONGO_BACKUP_ENABLED: false
+MONGO_BACKUP_NODE: "" # note: most likely the ip address of the instance on which to perform the backups
 MONGO_BACKUP_EBS_VOLUME_DEVICE: ""
 MONGO_BACKUP_EBS_VOLUME_ID: ""
-MONGO_BACKUP_VOLUME_MOUNT_PATH: "/mnt/mongo-backup"
-MONGO_BACKUP_NODE: "" # note: most likely the ip address of the instance on which to perform the backups
 MONGO_BACKUP_AUTH_DATABASE: ""
-MONGO_BACKUP_SNAPSHOT_DESC: "mongo-backup"
 MONGO_BACKUP_PRUNE_OLDER_THAN_DATE: ""  # passed to `date -d`; should be a relative date like "-30days"
 MONGO_BACKUP_SNITCH_URL: "" # Optional URL that will be used to ping a monitoring service (such as Dead Man's Snitch) upon successful completion of a backup.
+MONGO_BACKUP_VOLUME_MOUNT_PATH: "/mnt/mongo-backup"
+MONGO_BACKUP_SNAPSHOT_DESC: "mongo-backup"
 mongo_backup_script_path: "/usr/local/sbin/backup-mongo.sh"
 mongo_backup_cron:
   minute: '12'

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -172,19 +172,6 @@
     - "manage:db-replication"
     - "mongodb_key"
 
-- name: install prereqs for backup script
-  apt:
-    pkg: "{{ item }}"
-    state: present
-    update_cache: yes
-  with_items:
-    - jq
-  tags:
-    - "backup:mongo"
-    - "install"
-    - "install:app-requirements"
-    - "mongo_packages"
-
 # If skip_replica_set is true, this template will not contain a replica set stanza
 # because of the fact above.
 - name: copy configuration template
@@ -200,21 +187,44 @@
     - "manage:db-replication"
     - "update_mongod_conf"
 
+- name: check mongo backups enabled
+  set_fact:
+    enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+
 - name: install logrotate configuration
   template:
     src: mongo_logrotate.j2
     dest: /etc/logrotate.d/hourly/mongo
+  vars:
+    include_backup_log: enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"
     - "install:app-configuration"
     - "logrotate"
 
+- name: install prereqs for backup script
+  apt:
+    pkg: "{{ item }}"
+    state: present
+    update_cache: yes
+  with_items:
+    - jq
+  when:
+    - enable_mongo_backups
+  tags:
+    - "backup:mongo"
+    - "install"
+    - "install:app-requirements"
+    - "mongo_packages"
+
 - name: install backup script
   template:
     src: backup-mongo.sh.j2
     dest: "{{ mongo_backup_script_path }}"
     mode: 0700
+  when:
+    - enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"
@@ -229,6 +239,8 @@
     weekday: "{{ mongo_backup_cron.weekday | default('*') }}"
     job: "{{ mongo_backup_script_path }} >> {{ mongo_log_dir }}/mongo-backup.log 2>&1"
   become: yes
+  when:
+    - enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"
@@ -239,7 +251,8 @@
     fstype: ext4
     force: true
   ignore_errors: true
-  when: "'{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'"
+  when:
+    - enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -187,11 +187,12 @@
     - "manage:db-replication"
     - "update_mongod_conf"
 
-# this sets the enable_mongo_backups var if mongo backups are enabled AND we're currently running against the designated
-# mongo backup node.
+# This sets the is_backup_node var by checking whether
+# mongo backups are enabled AND we're currently running against the designated mongo backup node.
+# This allows backup-related tasks below to determine whether or not they should run on the current mongo node.
 - name: check mongo backups enabled
   set_fact:
-    enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+    is_backup_node: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
   tags:
     - "backup:mongo"
 
@@ -213,7 +214,7 @@
   with_items:
     - jq
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"
@@ -226,7 +227,7 @@
     dest: "{{ mongo_backup_script_path }}"
     mode: 0700
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"
@@ -242,7 +243,7 @@
     job: "{{ mongo_backup_script_path }} >> {{ mongo_log_dir }}/mongo-backup.log 2>&1"
   become: yes
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"
@@ -254,7 +255,7 @@
     force: true
   ignore_errors: true
   when:
-    - enable_mongo_backups
+    - is_backup_node
   tags:
     - "backup:mongo"
     - "install"

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -192,7 +192,8 @@
 # This allows backup-related tasks below to determine whether or not they should run on the current mongo node.
 - name: check mongo backups enabled
   set_fact:
-    is_backup_node: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+    is_backup_node: true
+  when: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
   tags:
     - "backup:mongo"
 

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -190,6 +190,8 @@
 - name: check mongo backups enabled
   set_fact:
     enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
+  tags:
+    - "backup:mongo"
 
 - name: install logrotate configuration
   template:

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -187,6 +187,8 @@
     - "manage:db-replication"
     - "update_mongod_conf"
 
+# this sets the enable_mongo_backups var if mongo backups are enabled AND we're currently running against the designated
+# mongo backup node.
 - name: check mongo backups enabled
   set_fact:
     enable_mongo_backups: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'
@@ -197,8 +199,6 @@
   template:
     src: mongo_logrotate.j2
     dest: /etc/logrotate.d/hourly/mongo
-  vars:
-    include_backup_log: enable_mongo_backups
   tags:
     - "backup:mongo"
     - "install"

--- a/playbooks/roles/mongo_3_2/tasks/main.yml
+++ b/playbooks/roles/mongo_3_2/tasks/main.yml
@@ -190,7 +190,7 @@
 # This sets the is_backup_node var by checking whether
 # mongo backups are enabled AND we're currently running against the designated mongo backup node.
 # This allows backup-related tasks below to determine whether or not they should run on the current mongo node.
-- name: check mongo backups enabled
+- name: determine if backup tasks should run
   set_fact:
     is_backup_node: true
   when: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,7 +12,6 @@
   size 1M
 }
 
-{% if include_backup_log %}
 {{ mongo_log_dir }}/mongo-backup.log {
   create
   compress
@@ -26,7 +25,6 @@
   rotate 90
   size 1M
 }
-{% endif %}
 
 {{ mongo_log_dir }}/mongodb.log {
   create

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,6 +12,7 @@
   size 1M
 }
 
+{% if include_backup_log %}
 {{ mongo_log_dir }}/mongo-backup.log {
   create
   compress
@@ -25,6 +26,7 @@
   rotate 90
   size 1M
 }
+{% endif %}
 
 {{ mongo_log_dir }}/mongodb.log {
   create

--- a/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
+++ b/playbooks/roles/mongo_3_2/templates/mongo_logrotate.j2
@@ -12,6 +12,7 @@
   size 1M
 }
 
+{% if is_backup_node %}
 {{ mongo_log_dir }}/mongo-backup.log {
   create
   compress
@@ -25,6 +26,7 @@
   rotate 90
   size 1M
 }
+{% endif %}
 
 {{ mongo_log_dir }}/mongodb.log {
   create


### PR DESCRIPTION
This backports the changes being introduced in https://github.com/edx/configuration/pull/5551/

Will be used for testing.

Results of the tests:

Note that I limited to the `backup:mongo` tag. I argue that this provides the results we want, because the only tasks that have been modified are also the only tasks that have this tag.

* Run against a normal (not the backup) node with backups enabled. All backup tasks are skipped as expected, and the logrotate config also excludes the backup log block:

```
(venv) ubuntu@instance:~/configuration/playbooks$ ansible-playbook -i 'NODE_IP_ADDRESS,' -vv          -u ubuntu --private-key=/home/ubuntu/olive-deployment          -e @/home/ubuntu/olive-internal/ansible/vars/stage-olivex.yml          -e @/home/ubuntu/olive-secure/ansible/vars/stage-olivex.yml mongo.yml -t backup:mongo

Using /home/ubuntu/configuration/playbooks/ansible.cfg as config file
statically included: /home/ubuntu/configuration/playbooks/roles/security/tasks/security-ubuntu.yml

PLAYBOOK: mongo.yml ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
2 plays in mongo.yml

PLAY [Bootstrap instance(s)] *******************************************************************************************************************************************************************************************************************************************************************************************************************************
META: ran handlers
META: ran handlers
META: ran handlers

PLAY [Install mongo] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [NODE_IP_ADDRESS]
META: ran handlers

TASK [mongo_3_2 : determine if backup tasks should run] ****************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:193
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'

skipping: [NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : install logrotate configuration] *********************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:200
changed: [NODE_IP_ADDRESS] => {"changed": true, "checksum": "3a539ffd1bde0140ebb7856dad13f3ad3169f2bf", "dest": "/etc/logrotate.d/hourly/mongo", "gid": 0, "group": "root", "md5sum": "5334c80e5fe30e994e2cbb1a14e4ec72", "mode": "0644", "owner": "root", "size": 416, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1576458363.35-165429990994897/source", "state": "file", "uid": 0}

TASK [mongo_3_2 : install prereqs for backup script] *******************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:210
skipping: [NODE_IP_ADDRESS] => (item=[])  => {"changed": false, "item": [], "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : install backup script] *******************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:225
skipping: [NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : add mongo backup script to cron] *********************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:236
skipping: [NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : format mongo backup volume] **************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:252
skipping: [NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
NODE_IP_ADDRESS               : ok=2    changed=1    unreachable=0    failed=0

INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: Gathering Facts ----------------------------------------------------------------- 0.88s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install logrotate configuration ------------------------------------------------- 0.69s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: determine if backup tasks should run -------------------------------------------- 0.03s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install prereqs for backup script ----------------------------------------------- 0.02s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: add mongo backup script to cron ------------------------------------------------- 0.02s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install backup script ----------------------------------------------------------- 0.02s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: format mongo backup volume ------------------------------------------------------ 0.01s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing:
Playbook Install mongo finished: 2019-12-16 01:06:03.847434, 7 total tasks.  0:00:01.713429 elapsed.
```

* Run against the backup node, with backups disabled (default configuration of `MONGO_BACKUP_ENABLED: false`). Note that all tasks are skipped, and the logrotate config also excludes the backup log block, as expected:

```
(venv) ubuntu@instance:~/configuration/playbooks$ ansible-playbook -i 'BACKUP_NODE_IP_ADDRESS,' -vv          -u ubuntu --private-key=/home/ubuntu/olive-deployment          -e @/home/ubuntu/olive-internal/ansible/vars/stage-olivex.yml          -e @/home/ubuntu/olive-secure/ansible/vars/stage-olivex.yml mongo.yml -t backup:mongo

Using /home/ubuntu/configuration/playbooks/ansible.cfg as config file
statically included: /home/ubuntu/configuration/playbooks/roles/security/tasks/security-ubuntu.yml

PLAYBOOK: mongo.yml ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
2 plays in mongo.yml

PLAY [Bootstrap instance(s)] *******************************************************************************************************************************************************************************************************************************************************************************************************************************
META: ran handlers
META: ran handlers
META: ran handlers

PLAY [Install mongo] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [BACKUP_NODE_IP_ADDRESS]
META: ran handlers

TASK [mongo_3_2 : determine if backup tasks should run] ****************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:193
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'

skipping: [BACKUP_NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : install logrotate configuration] *********************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:200
changed: [BACKUP_NODE_IP_ADDRESS] => {"changed": true, "checksum": "3a539ffd1bde0140ebb7856dad13f3ad3169f2bf", "dest": "/etc/logrotate.d/hourly/mongo", "gid": 0, "group": "root", "md5sum": "5334c80e5fe30e994e2cbb1a14e4ec72", "mode": "0644", "owner": "root", "size": 416, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1576458619.09-271556282714301/source", "state": "file", "uid": 0}

TASK [mongo_3_2 : install prereqs for backup script] *******************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:210
skipping: [BACKUP_NODE_IP_ADDRESS] => (item=[])  => {"changed": false, "item": [], "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : install backup script] *******************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:225
skipping: [BACKUP_NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : add mongo backup script to cron] *********************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:236
skipping: [BACKUP_NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}

TASK [mongo_3_2 : format mongo backup volume] **************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:252
skipping: [BACKUP_NODE_IP_ADDRESS] => {"changed": false, "skip_reason": "Conditional result was False", "skipped": true}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
BACKUP_NODE_IP_ADDRESS               : ok=2    changed=1    unreachable=0    failed=0

INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: Gathering Facts ----------------------------------------------------------------- 0.83s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install logrotate configuration ------------------------------------------------- 0.69s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: determine if backup tasks should run -------------------------------------------- 0.03s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install prereqs for backup script ----------------------------------------------- 0.02s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: add mongo backup script to cron ------------------------------------------------- 0.02s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install backup script ----------------------------------------------------------- 0.02s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_tiMONGO_BACKUP_ENABLEDming: format mongo backup volume ------------------------------------------------------ 0.01s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing:
Playbook Install mongo finished: 2019-12-16 01:10:19.597523, 7 total tasks.  0:00:01.664079 elapsed.
```

* Run against the backup node again, this time with `MONGO_BACKUP_ENABLED: true`. Note that all tasks run. The logrotate configuration also includes the block for backup log file:

```
(venv) ubuntu@instance:~/configuration/playbooks$ ansible-playbook -i 'BACKUP_NODE_IP_ADDRESS,' -vv          -u ubuntu --private-key=/home/ubuntu/olive-deployment          -e @/home/ubuntu/olive-internal/ansible/vars/stage-olivex.yml          -e @/home/ubuntu/olive-secure/ansible/vars/stage-olivex.yml mongo.yml -t backup:mongo

Using /home/ubuntu/configuration/playbooks/ansible.cfg as config file
statically included: /home/ubuntu/configuration/playbooks/roles/security/tasks/security-ubuntu.yml

PLAYBOOK: mongo.yml ****************************************************************************************************************************************************************************************************************************************************************************************************************************************
2 plays in mongo.yml

PLAY [Bootstrap instance(s)] *******************************************************************************************************************************************************************************************************************************************************************************************************************************
META: ran handlers
META: ran handlers
META: ran handlers

PLAY [Install mongo] ***************************************************************************************************************************************************************************************************************************************************************************************************************************************

TASK [Gathering Facts] *************************************************************************************************************************************************************************************************************************************************************************************************************************************
ok: [BACKUP_NODE_IP_ADDRESS]
META: ran handlers

TASK [mongo_3_2 : determine if backup tasks should run] ****************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:193
 [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: MONGO_BACKUP_ENABLED and '{{ ansible_default_ipv4.address|default(ansible_all_ipv4_addresses[0]) }}' == '{{ MONGO_BACKUP_NODE }}'

ok: [BACKUP_NODE_IP_ADDRESS] => {"ansible_facts": {"is_backup_node": true}, "changed": false}

TASK [mongo_3_2 : install logrotate configuration] *********************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:200
changed: [BACKUP_NODE_IP_ADDRESS] => {"changed": true, "checksum": "51c56a8803de78a552fa57deecca7b148ba6cd0e", "dest": "/etc/logrotate.d/hourly/mongo", "gid": 0, "group": "root", "md5sum": "62cc23ad1607a94406aa46766ee5dbb3", "mode": "0644", "owner": "root", "size": 596, "src": "/home/ubuntu/.ansible/tmp/ansible-tmp-1576458701.72-270815179625399/source", "state": "file", "uid": 0}

TASK [mongo_3_2 : install prereqs for backup script] *******************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:210
ok: [BACKUP_NODE_IP_ADDRESS] => (item=[u'jq']) => {"cache_update_time": 1576458703, "cache_updated": true, "changed": false, "item": ["jq"]}

TASK [mongo_3_2 : install backup script] *******************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:225
ok: [BACKUP_NODE_IP_ADDRESS] => {"changed": false, "gid": 0, "group": "root", "mode": "0700", "owner": "root", "path": "/usr/local/sbin/backup-mongo.sh", "size": 6453, "state": "file", "uid": 0}

TASK [mongo_3_2 : add mongo backup script to cron] *********************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:236
ok: [BACKUP_NODE_IP_ADDRESS] => {"changed": false, "envs": [], "jobs": ["log-ntp-alerts", "mongostat logging job", "mongo backup job"]}

TASK [mongo_3_2 : format mongo backup volume] **************************************************************************************************************************************************************************************************************************************************************************************************************
task path: /home/ubuntu/configuration/playbooks/roles/mongo_3_2/tasks/main.yml:252
changed: [BACKUP_NODE_IP_ADDRESS] => {"changed": true}
META: ran handlers
META: ran handlers

PLAY RECAP *************************************************************************************************************************************************************************************************************************************************************************************************************************************************
BACKUP_NODE_IP_ADDRESS               : ok=7    changed=2    unreachable=0    failed=0

INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install prereqs for backup script ----------------------------------------------- 2.61s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: format mongo backup volume ------------------------------------------------------ 1.58s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: Gathering Facts ----------------------------------------------------------------- 0.83s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install logrotate configuration ------------------------------------------------- 0.70s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: install backup script ----------------------------------------------------------- 0.59s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: add mongo backup script to cron ------------------------------------------------- 0.28s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing: determine if backup tasks should run -------------------------------------------- 0.03s
INFO:/home/ubuntu/configuration/playbooks/callback_plugins/task_timing:
Playbook Install mongo finished: 2019-12-16 01:11:47.215001, 7 total tasks.  0:00:06.655695 elapsed.
```