### PR TITLE
SE-2208 configure cms gunicorn timeout

### DIFF
--- a/playbooks/roles/edxapp/defaults/main.yml
+++ b/playbooks/roles/edxapp/defaults/main.yml
@@ -1245,6 +1245,7 @@ edxapp_cms_gunicorn_port: 8010
 edxapp_cms_gunicorn_host: 127.0.0.1
 edxapp_lms_gunicorn_port: 8000
 edxapp_lms_gunicorn_host: 127.0.0.1
+edxapp_cms_gunicorn_timeout: 300
 
 # These vars are for creating the application json config
 # files.  There are two for each service that uses the

--- a/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
+++ b/playbooks/roles/edxapp/templates/cms_gunicorn.py.j2
@@ -6,7 +6,7 @@ gunicorn configuration file: http://docs.gunicorn.org/en/develop/configure.html
 import multiprocessing
 
 preload_app = False
-timeout = 300
+timeout = {{ edxapp_cms_gunicorn_timeout }}
 bind = "{{ edxapp_cms_gunicorn_host }}:{{ edxapp_cms_gunicorn_port }}"
 pythonpath = "{{ edxapp_code_dir }}"
 


### PR DESCRIPTION
This is part of a solution to allow longer time to load for some pages
in the CMS that take longer than 5 minutes (300s) to load.

**Test instructions**:

NOTE: can be tested as part of ~~https://github.com/edx-olive/olive-internal/pull/21~~ https://github.com/edx-olive/olive-secure/pull/165

- sanity check templating and defaults
- set `edxapp_cms_gunicorn_timeout` to something other than 300 in vars for ansible-playbook
- deploy
- shell into an instance and verify that the timeout has been updated in `/edx/app/edxapp/cms_gunicorn.py`.

**Reviewer**:

- [x] @itsjeyd 