### PR TITLE
Downgrade setuptools and update MySQL-python to mysqlclient

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -23,4 +23,4 @@ boto3==1.4.4
 pymongo==3.1
 
 # Needed for the mysql_db module
-MySQL-python==1.2.5
+mysqlclient==1.3.7

--- a/util/jenkins/build-ami.sh
+++ b/util/jenkins/build-ami.sh
@@ -129,6 +129,7 @@ if [[ ! -z "$identity_path" ]]; then
 fi
 
 cd configuration
+pip install --upgrade 'setuptools<45.0.0'
 pip install -r requirements.txt
 
 cd util/vpc-tools/


### PR DESCRIPTION
This PR adds the command to explicitly downgrade the setuptools version to <45, since version 45 does not support python 2.7. It also updates the MySQL-python library to mysqlclient as the former is no longer maintained.

**Testing Instructions:**
1. Use this branch and build a jenkins AMI (already done it for [build#266](https://admin.edx-flatu.org:8080/job/build-ami/266/))
2. Verify the build succeeds without the error message `ERROR: Package 'setuptools' requires a different Python: 2.7.12 not in '>=3.5'` 

**Reviewers:**

- [x] @gabor-boros 